### PR TITLE
fix(AHRSIMU): fix the parameter sequence

### DIFF
--- a/00-STM32_LIBRARIES/tm_stm32_ahrs_imu.c
+++ b/00-STM32_LIBRARIES/tm_stm32_ahrs_imu.c
@@ -50,7 +50,7 @@ void calculateAngles(TM_AHRSIMU_t* AHRSIMU) {
     }
 }
 
-void TM_AHRSIMU_Init(TM_AHRSIMU_t* AHRSIMU, float beta, float sampleRate, float inclination) {
+void TM_AHRSIMU_Init(TM_AHRSIMU_t* AHRSIMU, float sampleRate, float beta, float inclination) {
     AHRSIMU->_beta = beta;
     AHRSIMU->_sampleRate = 1 / sampleRate;
     AHRSIMU->Inclination = inclination;


### PR DESCRIPTION
- the sequence of parameters of function `TM_AHRSIMU_Init` in it's definition in source file is `AHRSIMU, beta, sampleRate, inclination` while in the declearation in header file is `AHRSIMU, sampleRate, beta, inclination` 
- I change the sequence both same with the [API manual book website](https://stm32f4-discovery.net/hal_api/group___t_m___a_h_r_s_i_m_u___functions.html#gabff1b65545a16c99279f0986cd990a6c)